### PR TITLE
🚀 RELEASE: Color picker bug fix & improvements

### DIFF
--- a/class-wp-osa.php
+++ b/class-wp-osa.php
@@ -68,7 +68,13 @@ if ( ! class_exists( 'WP_OSA' ) ) :
 			wp_enqueue_script( 'jquery' );
 
 			// Color Picker.
-			wp_enqueue_style( 'wp-color-picker' );
+			wp_enqueue_script(
+				'iris',
+				admin_url( 'js/iris.min.js' ),
+				array( 'jquery-ui-draggable', 'jquery-ui-slider', 'jquery-touch-punch' ),
+				false,
+				1
+			);
 
 			// Media Uploader.
 			wp_enqueue_media();
@@ -653,7 +659,7 @@ if ( ! class_exists( 'WP_OSA' ) ) :
 			$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'], $args['placeholder'] ) );
 			$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
 
-			$html  = sprintf( '<input type="text" class="%1$s-text wp-color-picker-field" id="%2$s[%3$s]" name="%2$s[%3$s]" value="%4$s" data-default-color="%5$s" placeholder="%6$s" />', $size, $args['section'], $args['id'], $value, $args['std'], $args['placeholder'] );
+			$html  = sprintf( '<input type="text" class="%1$s-text color-picker" id="%2$s[%3$s]" name="%2$s[%3$s]" value="%4$s" data-default-color="%5$s" placeholder="%6$s" />', $size, $args['section'], $args['id'], $value, $args['std'], $args['placeholder'] );
 			$html .= $this->get_field_description( $args );
 
 			echo $html;
@@ -781,8 +787,8 @@ if ( ! class_exists( 'WP_OSA' ) ) :
 			<script>
 				jQuery( document ).ready( function( $ ) {
 
-				//Initiate Color Picker
-				// $('.wp-color-picker-field').wpColorPicker();
+				//Initiate Color Picker.
+				$('.color-picker').iris();
 
 				// Switches option sections
 				$( '.group' ).hide();
@@ -901,6 +907,9 @@ if ( ! class_exists( 'WP_OSA' ) ) :
 					position: absolute;
 					left: 0;
 					width: 99%;
+				}
+				.group .form-table input.color-picker {
+					max-width: 100px;
 				}
 			</style>
 			<?php

--- a/class-wp-osa.php
+++ b/class-wp-osa.php
@@ -650,10 +650,10 @@ if ( ! class_exists( 'WP_OSA' ) ) :
 		 */
 		function callback_color( $args ) {
 
-			$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'] ) );
+			$value = esc_attr( $this->get_option( $args['id'], $args['section'], $args['std'], $args['placeholder'] ) );
 			$size  = isset( $args['size'] ) && ! is_null( $args['size'] ) ? $args['size'] : 'regular';
 
-			$html  = sprintf( '<input type="text" class="%1$s-text wp-color-picker-field" id="%2$s[%3$s]" name="%2$s[%3$s]" value="%4$s" data-default-color="%5$s" />', $size, $args['section'], $args['id'], $value, $args['std'] );
+			$html  = sprintf( '<input type="text" class="%1$s-text wp-color-picker-field" id="%2$s[%3$s]" name="%2$s[%3$s]" value="%4$s" data-default-color="%5$s" placeholder="%6$s" />', $size, $args['section'], $args['id'], $value, $args['std'], $args['placeholder'] );
 			$html .= $this->get_field_description( $args );
 
 			echo $html;

--- a/wposa-init.php
+++ b/wposa-init.php
@@ -242,10 +242,11 @@ if ( class_exists( 'WP_OSA' ) ) {
 	$wposa_obj->add_field(
 		'wposa_other',
 		array(
-			'id'   => 'color',
-			'type' => 'color',
-			'name' => __( 'Color', 'WPOSA' ),
-			'desc' => __( 'Color description', 'WPOSA' ),
+			'id'          => 'color',
+			'type'        => 'color',
+			'name'        => __( 'Color', 'WPOSA' ),
+			'desc'        => __( 'Color description', 'WPOSA' ),
+			'placeholder' => __( '#5F4B8B', 'WPOSA' ),
 		)
 	);
 


### PR DESCRIPTION
This fixes #8 by switching the color picker JavaScript to [Iris](http://automattic.github.io/Iris/) from Automattic, and the code to include it is base off [this article](https://paulund.co.uk/adding-a-new-color-picker-with-wordpress-3-5).

Also, it's using the [Pantone 2018 Color of the Year](https://www.pantone.com/color-of-the-year-2018-tools-for-designers) as the placeholder hex code :sunglasses: 

🐛 **FIX:**

- Replaced the old color picker with Iris

📦 **NEW:**

- Placeholder option for color picker input field

📷 **SCREENSHOT:**

![screenshot-3](https://user-images.githubusercontent.com/9917957/37864401-9e8916fa-2f44-11e8-8928-3a6f718ff2b5.jpg)

- default
- active